### PR TITLE
fix: build undefined with mingw32 windows

### DIFF
--- a/TTKCommon/TTKCommon.pri
+++ b/TTKCommon/TTKCommon.pri
@@ -23,9 +23,9 @@ INCLUDEPATH += \
 
 win32{
     QT += xml
+
     msvc{
         HEADERS += \
-            $$PWD/TTKLibrary/ttkabstractmovedialog.h \
             $$PWD/TTKLibrary/ttkabstractmovedialog.h \
             $$PWD/TTKLibrary/ttkabstractmoveresizewidget.h \
             $$PWD/TTKLibrary/ttkabstractmovewidget.h \
@@ -40,5 +40,37 @@ win32{
             $$PWD/TTKLibrary/ttkglobalhelper.h \
             $$PWD/TTKLibrary/ttksemaphoreloop.h \
             $$PWD/TTKLibrary/ttktime.h
-    }
+         }
+
+    gcc{
+        HEADERS += \
+             $$PWD/TTKLibrary/ttkabstractmoveresizewidget.h \
+             $$PWD/TTKLibrary/ttkdesktopwrapper.h \
+#            $$PWD/TTKLibrary/ttkabstractmovedialog.h \
+#            $$PWD/TTKLibrary/ttkabstractmovewidget.h \
+#            $$PWD/TTKLibrary/ttkabstractresizeinterface.h \
+#            $$PWD/TTKLibrary/ttkabstractthread.h \
+#            $$PWD/TTKLibrary/ttkabstractxml.h \
+#            $$PWD/TTKLibrary/ttkclickedgroup.h \
+#            $$PWD/TTKLibrary/ttkclickedlabel.h \
+#            $$PWD/TTKLibrary/ttkclickedslider.h \
+#            $$PWD/TTKLibrary/ttkcryptographichash.h \
+#            $$PWD/TTKLibrary/ttkglobalhelper.h \
+#            $$PWD/TTKLibrary/ttksemaphoreloop.h \
+#            $$PWD/TTKLibrary/ttktime.h
+
+        SOURCES += \
+             $$PWD/TTKLibrary/ttkabstractmoveresizewidget.cpp \
+             $$PWD/TTKLibrary/ttkdesktopwrapper.cpp \
+#            $$PWD/TTKLibrary/ttkabstractmovedialog.cpp \
+#            $$PWD/TTKLibrary/ttkabstractmovewidget.cpp \
+#            $$PWD/TTKLibrary/ttkabstractthread.cpp \
+#            $$PWD/TTKLibrary/ttkabstractxml.cpp \
+#            $$PWD/TTKLibrary/ttkclickedgroup.cpp \
+#            $$PWD/TTKLibrary/ttkclickedlabel.cpp \
+#            $$PWD/TTKLibrary/ttkcryptographichash.cpp \
+#            $$PWD/TTKLibrary/ttkglobalhelper.cpp \
+#            $$PWD/TTKLibrary/ttksemaphoreloop.cpp \
+#            $$PWD/TTKLibrary/ttktime.cpp
+        }
 }


### PR DESCRIPTION
- OS: windows 10
- Qt: 5.15.2 mingw32
- Tool: qmake
The cause of the error is the lack of source files .cpp
```
release/ttkmoveresizewidget.o:ttkmoveresizewidget.cpp:(.text+0x11): undefined reference to `TTKAbstractMoveResizeWidget::TTKAbstractMoveResizeWidget(QWidget*)'
release/ttkmoveresizewidget.o:ttkmoveresizewidget.cpp:(.text.unlikely+0x3): undefined reference to `TTKAbstractMoveResizeWidget::~TTKAbstractMoveResizeWidget()'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.text+0x67): undefined reference to `TTKAbstractMoveResizeWidget::qt_metacast(char const*)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.text+0x81): undefined reference to `TTKAbstractMoveResizeWidget::qt_metacall(QMetaObject::Call, int, void**)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.text$_ZN19TTKMoveResizeWidgetD1Ev[__ZN19TTKMoveResizeWidgetD1Ev]+0xe): undefined reference to `TTKAbstractMoveResizeWidget::~TTKAbstractMoveResizeWidget()'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.text$_ZN19TTKMoveResizeWidgetD0Ev[__ZN19TTKMoveResizeWidgetD0Ev]+0x14): undefined reference to `TTKAbstractMoveResizeWidget::~TTKAbstractMoveResizeWidget()'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.text$_ZThn8_N19TTKMoveResizeWidgetD1Ev[__ZThn8_N19TTKMoveResizeWidgetD1Ev]+0x12): undefined reference to `TTKAbstractMoveResizeWidget::~TTKAbstractMoveResizeWidget()'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.text$_ZThn8_N19TTKMoveResizeWidgetD0Ev[__ZThn8_N19TTKMoveResizeWidgetD0Ev]+0x17): undefined reference to `TTKAbstractMoveResizeWidget::~TTKAbstractMoveResizeWidget()'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.rdata$_ZTV19TTKMoveResizeWidget[__ZTV19TTKMoveResizeWidget]+0x20): undefined reference to `TTKAbstractMoveResizeWidget::eventFilter(QObject*, QEvent*)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.rdata$_ZTV19TTKMoveResizeWidget[__ZTV19TTKMoveResizeWidget]+0x54): undefined reference to `TTKAbstractMoveResizeWidget::mousePressEvent(QMouseEvent*)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.rdata$_ZTV19TTKMoveResizeWidget[__ZTV19TTKMoveResizeWidget]+0x58): undefined reference to `TTKAbstractMoveResizeWidget::mouseReleaseEvent(QMouseEvent*)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.rdata$_ZTV19TTKMoveResizeWidget[__ZTV19TTKMoveResizeWidget]+0x60): undefined reference to `TTKAbstractMoveResizeWidget::mouseMoveEvent(QMouseEvent*)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.rdata$_ZTV19TTKMoveResizeWidget[__ZTV19TTKMoveResizeWidget]+0x80): undefined reference to `TTKAbstractMoveResizeWidget::paintEvent(QPaintEvent*)'
release/moc_ttkmoveresizewidget.o:moc_ttkmoveresizewidget.cpp:(.rdata+0x0): undefined reference to `TTKAbstractMoveResizeWidget::staticMetaObject'
```