### PR TITLE
fix: [Progress Widgets] Update QTimer and QPropertyAnimation initialization

### DIFF
--- a/TTKModule/Progress/donutWaitProgressWidget/ttkdonutwaitprogresswidget.cpp
+++ b/TTKModule/Progress/donutWaitProgressWidget/ttkdonutwaitprogresswidget.cpp
@@ -11,7 +11,7 @@ TTKDonutWaitProgressWidget::TTKDonutWaitProgressWidget(QWidget *parent)
       m_rotateDelta(36),
       m_rotateAngle(0)
 {
-    m_timer = new QTimer;
+    m_timer = new QTimer(this);
     connect(m_timer, SIGNAL(timeout()), this, SLOT(update()));
 
     m_timer->start(100);

--- a/TTKModule/Progress/roundProgressWidget/ttkroundprogresswidget.cpp
+++ b/TTKModule/Progress/roundProgressWidget/ttkroundprogresswidget.cpp
@@ -54,7 +54,7 @@ void TTKRoundProgressWidget::setRange(float min, float max)
 
 void TTKRoundProgressWidget::setText(float value)
 {
-    QPropertyAnimation* animation = new QPropertyAnimation(this, "m_value");
+    QPropertyAnimation* animation = new QPropertyAnimation(this, "m_value", this);
     animation->setDuration(TTK_DN_S2MS /2);
     animation->setStartValue(m_value);
     animation->setEndValue(value);

--- a/TTKModule/Progress/zoomWaitProgressWidget/ttkzoomwaitprogresswidget.cpp
+++ b/TTKModule/Progress/zoomWaitProgressWidget/ttkzoomwaitprogresswidget.cpp
@@ -11,7 +11,7 @@ TTKZoomWaitProgressWidget::TTKZoomWaitProgressWidget(QWidget *parent)
       m_radious(0),
       m_minRadious(0)
 {
-    m_timer = new QTimer;
+    m_timer = new QTimer(this);
     connect(m_timer, SIGNAL(timeout()), this, SLOT(update()));
 
     m_timer->start(100);


### PR DESCRIPTION
Updated the initialization of QTimer in the TTKDonutWaitProgressWidget
and TTKZoomWaitProgressWidget classes to ensure proper parent-child
relationship. This change helps in managing the memory of the timer
objects more effectively.

Additionally, modified the QPropertyAnimation initialization in the
TTKRoundProgressWidget to include the parent parameter, improving
resource management.

- Ensures proper memory management for QTimer
- Enhances resource handling for QPropertyAnimation

Log: Update QTimer and QPropertyAnimation initialization
